### PR TITLE
Chore: Add Makefile for Build Automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Makefile for Guyana Flag & Logo Renderer
+
+# Detect the Operating System
+ifeq ($(OS),Windows_NT)
+    # Windows Settings (MinGW)
+    LIBS = -lfreeglut -lopengl32 -lglu32
+    TARGET = flag_app.exe
+    RM = del
+else
+    # macOS Settings
+    LIBS = -framework OpenGL -framework GLUT
+    TARGET = flag_app
+    RM = rm -f
+endif
+
+# Default task: Compile and Run
+all: build run
+
+# Compile the source code
+build:
+	g++ src/main.cpp -o $(TARGET) $(LIBS)
+
+# Execute the program
+run:
+	./$(TARGET)
+
+# Clean up build files
+clean:
+	$(RM) $(TARGET)


### PR DESCRIPTION
This PR introduces a Makefile to automate the build and execution process.

Improvements:

- One-command execution: The Teacher only needs to type  `make`  to compile and run the project.

- Cross-platform support: The Makefile automatically detects if the user is on macOS or Windows and applies the correct compiler flags and libraries.

- Cleanup: Added a make clean command to remove executable files.

- This enhancement ensures a smooth and professional handoff for final evaluation.